### PR TITLE
Remove `basisOfRecord` from event core

### DIFF
--- a/sql/dwc_event.sql
+++ b/sql/dwc_event.sql
@@ -11,7 +11,6 @@ SELECT
   'https://doi.org/10.15468/ap9ejd'     AS datasetID,
   'POV'                                 AS institutionCode,
   'Monitoring of fishes and crustaceans by Province East Flanders in Flanders, Belgium' AS datasetName,
-  'HumanObservation'                    AS basisOfRecord,
   o."SamplingProtocol"                  AS samplingProtocol, -- targeted monitoring
 -- EVENT
   o."ObservationIdentifier"             AS eventID,


### PR DESCRIPTION
`basisOfRecord` is not mapped to any field of Darwin Core Event, so it is removed.